### PR TITLE
fix: add Pipfile to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ venv
 *.egg-info
 .DS_Store
 .vscode
+Pipfile


### PR DESCRIPTION
After following the instructions on MacOS, I found that the created Pipfile was showing as uncommitted.

Thanks for this plugin, it was a really good basis for creating my own for exporting results as GitHub flavoured markdown tables (for pasting into GitHub issues / gists etc).